### PR TITLE
Update PlanningTokenClass

### DIFF
--- a/BuildingClass.h
+++ b/BuildingClass.h
@@ -321,7 +321,7 @@ public:
 	bool IsDamaged; // AI handholder for repair logic,
 	bool IsFogged;
 	bool IsBeingRepaired; // show animooted repair wrench
-	bool unknown_bool_6E9;
+	bool HasBuildUp;
 	bool StuffEnabled; // status set by EnableStuff() and DisableStuff()
 	char HasCloakingData; // some fugly buffers
 	byte CloakRadius; // from Type->CloakRadiusInCells

--- a/BuildingTypeClass.h
+++ b/BuildingTypeClass.h
@@ -53,6 +53,9 @@ public:
 	virtual SHPStruct* LoadBuildup() R0;
 
 	//non-virtual
+	void ClearBuildUp()
+		{ JMP_THIS(0x465AF0); }
+
 	bool IsVehicle() const
 		{ JMP_THIS(0x465D40); }
 

--- a/FootClass.h
+++ b/FootClass.h
@@ -36,8 +36,8 @@ public:
 	virtual bool IsLeavingMap() const R0;
 	virtual bool vt_entry_4E0() const R0;
 	virtual bool CanDeployNow() const R0;
-	virtual void vt_entry_4E8(CellStruct* pCell) RX;
-	virtual void vt_entry_4EC(CellStruct* pCell) RX;
+	virtual void AddSensorsAt(CellStruct cell) RX;
+	virtual void RemoveSensorsAt(CellStruct cell) RX;
 	virtual CoordStruct* vt_entry_4F0(CoordStruct* pCrd) R0;
 	virtual void vt_entry_4F4() RX;
 	virtual bool vt_entry_4F8() R0;
@@ -55,7 +55,7 @@ public:
 		VoxelStruct *VXL, int HVAFrameIndex, int Flags, IndexClass<int, int> *Cache, RectangleStruct *Rectangle,
 		Point2D *CenterPoint, Matrix3D *Matrix, DWORD dwUnk8, DWORD DrawFlags, DWORD dwUnk10) RX;
 
-	virtual void vt_entry_514() RX;
+	virtual void GoBerzerk() RX;
 	virtual void Panic() RX;
 	virtual void UnPanic() RX; //never
 	virtual void PlayIdleAnim(int nIdleAnimNumber) RX;

--- a/FootClass.h
+++ b/FootClass.h
@@ -35,7 +35,7 @@ public:
 	virtual void RemoveGunner(FootClass* Gunner) RX;
 	virtual bool IsLeavingMap() const R0;
 	virtual bool vt_entry_4E0() const R0;
-	virtual bool vt_entry_4E4() const R0;
+	virtual bool CanDeployNow() const R0;
 	virtual void vt_entry_4E8(CellStruct* pCell) RX;
 	virtual void vt_entry_4EC(CellStruct* pCell) RX;
 	virtual CoordStruct* vt_entry_4F0(CoordStruct* pCrd) R0;

--- a/Fundamentals.h
+++ b/Fundamentals.h
@@ -8,16 +8,19 @@ namespace Unsorted
 {
 	static const int& CurrentFrame = *reinterpret_cast<int*>(0xA8ED84);
 
-	// The length of a cell in isometric projection
+	// The length of a cell in its isometric projection
 	// If an object's Height is above this value it's considered as in-air
 	constexpr int CellHeight = 208;
 	// Leptons of a cell's diagonal /2 /sin(60deg)
 	// LeptonsPerCell *sqrt(2) /2 */ (sqrt(3)/2)
-	// 256 * sqrt(2/3) = 209
-	// with some precision loss
+	// 256 * sqrt(2/3)
 
 	// The height in the middle of a cell, which is therefore CellHeight/2
 	constexpr int LevelHeight = 104;
+	// The game actually calculated this one and multiply it by 2 for CellHeight
+	// cot(deg2rad(60)) * leptonsOfCellDiagonal /2
+	// tan(pi/2-pi/3) * sqrt(2 * 256^2) * 0.5
+	// sqrt(3)/3 * 362.03 *0.5
 
 	// Leptons per cell.
 	constexpr int LeptonsPerCell = 256;

--- a/Fundamentals.h
+++ b/Fundamentals.h
@@ -8,18 +8,23 @@ namespace Unsorted
 {
 	static const int& CurrentFrame = *reinterpret_cast<int*>(0xA8ED84);
 
-	// The height in the middle of a cell with a slope of 30 degrees
-	const int LevelHeight = 104;
-	// tan(deg2rad(90) - deg2rad(60)) * sqrt(2 * 256 ^ 2) * 0.5
-	// cot(deg2rad(30)) * diagonal_leptons_per_cell * 0.5
-	// sqrt(3)/3 * 362.038 * 0.5
-	
+	// The length of a cell in isometric projection
+	// If an object's Height is above this value it's considered as in-air
+	constexpr int CellHeight = 208;
+	// Leptons of a cell's diagonal /2 /sin(60deg)
+	// LeptonsPerCell *sqrt(2) /2 */ (sqrt(3)/2)
+	// 256 * sqrt(2/3) = 209
+	// with some precision loss
+
+	// The height in the middle of a cell, which is therefore CellHeight/2
+	constexpr int LevelHeight = 104;
+
 	// Leptons per cell.
-	const int LeptonsPerCell = 256;
+	constexpr int LeptonsPerCell = 256;
 
 	// Cell width in pixels.
-	const int CellWidthInPixels = 60;
+	constexpr int CellWidthInPixels = 60;
 
 	// Cell height in pixels.
-	const int CellHeightInPixels = 30;
+	constexpr int CellHeightInPixels = 30;
 }

--- a/PlanningTokenClass.h
+++ b/PlanningTokenClass.h
@@ -18,23 +18,25 @@ public:
 class PlanningTokenClass
 {
 public:
-
 	void Clear()
-		{ JMP_THIS(0x636310); }
+	{
+		JMP_THIS(0x636310);
+	}
 
 	//===========================================================================
 	//===== Properties ==========================================================
 	//===========================================================================
 
 public:
-	TechnoClass * OwnerUnit;
-	DynamicVectorClass<PlanningNode*> PlanningNodes;
+	TechnoClass *OwnerUnit;
+	DynamicVectorClass<PlanningNode *> PlanningNodes;
 
 	DECLARE_PROPERTY_ARRAY(DWORD, unknown, 0x1C);
 
 	int field_8C;
 	int ClosedLoopNodeCount;
 	int StepsToClosedLoop;
-	DWORD field_98;
+
+	DECLARE_PROPERTY(DWORD, field_98);
 };
 static_assert(sizeof(PlanningTokenClass) == 0x9C);

--- a/PlanningTokenClass.h
+++ b/PlanningTokenClass.h
@@ -4,6 +4,17 @@
 
 class TechnoClass;
 
+class PlanningNode
+{
+public:
+	DWORD field_0;
+	DWORD field_4;
+	DWORD field_8;
+	DWORD field_C;
+	int field_10;
+	DWORD field_14;
+};
+
 class PlanningTokenClass
 {
 public:
@@ -17,5 +28,13 @@ public:
 
 public:
 	TechnoClass * OwnerUnit;
-	// more fields should be here
+	DynamicVectorClass<PlanningNode*> PlanningNodes;
+
+	DECLARE_PROPERTY_ARRAY(DWORD, unknown, 0x1C);
+
+	int field_8C;
+	int ClosedLoopNodeCount;
+	int StepsToClosedLoop;
+	DWORD field_98;
 };
+static_assert(sizeof(PlanningTokenClass) == 0x9C);

--- a/TechnoClass.h
+++ b/TechnoClass.h
@@ -189,14 +189,14 @@ public:
 	virtual bool ShouldNotBeCloaked() const R0;
 	virtual DirStruct* TurretFacing(DirStruct* pBuffer) const R0;
 	virtual bool IsArmed() const R0; // GetWeapon(primary) && GetWeapon(primary)->WeaponType
-	virtual void vt_entry_2B0() const RX;
+	virtual bool vt_entry_2B0() const R0;
 	virtual double GetStoragePercentage() const R0;
 	virtual int GetPipFillLevel() const R0;
 	virtual int GetRefund() const R0;
 	virtual int GetThreatValue() const R0;
 	virtual bool vt_entry_2C4(DWORD dwUnk) R0;
 	virtual DWORD vt_entry_2C8(DWORD dwUnk, DWORD dwUnk2) R0;
-	virtual bool vt_entry_2CC(DWORD dwUnk) R0;
+	virtual bool CanReachLocation(CoordStruct* pCoord) R0;
 	virtual int GetCrewCount() const R0;
 	virtual int GetAntiAirValue() const R0;
 	virtual int GetAntiArmorValue() const R0;
@@ -206,8 +206,8 @@ public:
 	virtual int SelectNavalTargeting(AbstractClass *pTarget) const R0;
 	virtual int GetZAdjustment() const R0;
 	virtual ZGradient GetZGradient() const RT(ZGradient);
-	virtual CellStruct* GetSomeCellStruct() const R0;
-	virtual void SetSomeCellStruct(CellStruct* Buffer) RX;
+	virtual CellStruct* GetSomeCellStruct(CellStruct* buffer) const R0;
+	virtual void SetSomeCellStruct(CellStruct coord) RX;
 	virtual CellStruct* vt_entry_2FC(CellStruct* Buffer, DWORD dwUnk2, DWORD dwUnk3) const R0;
 	virtual CoordStruct * vt_entry_300(CoordStruct * Buffer, DWORD dwUnk2) const R0;
 	virtual DWORD vt_entry_304(DWORD dwUnk, DWORD dwUnk2) const R0;
@@ -592,7 +592,7 @@ public:
 
 	float            PitchAngle; // not exactly, and it doesn't affect the drawing, only internal state of a dropship
 	DECLARE_PROPERTY(CDTimerClass, DiskLaserTimer);
-	DWORD            unknown_2F8;
+	int           	 ROF;
 	int              Ammo;
 	int              Value; // set to actual cost when this gets queued in factory, updated only in building's 42C
 

--- a/TechnoClass.h
+++ b/TechnoClass.h
@@ -196,7 +196,7 @@ public:
 	virtual int GetThreatValue() const R0;
 	virtual bool vt_entry_2C4(DWORD dwUnk) R0;
 	virtual DWORD vt_entry_2C8(DWORD dwUnk, DWORD dwUnk2) R0;
-	virtual bool CanReachLocation(CoordStruct* pCoord) R0;
+	virtual bool CanReachLocation(const CoordStruct& coord) R0;
 	virtual int GetCrewCount() const R0;
 	virtual int GetAntiAirValue() const R0;
 	virtual int GetAntiArmorValue() const R0;

--- a/UnitClass.h
+++ b/UnitClass.h
@@ -52,9 +52,9 @@ public:
 	void UpdateVisceroid() JMP_THIS(0x737180);
 	void UpdateDisguise() JMP_THIS(0x7468C0);
 	void Update() JMP_THIS(0x7360C0);
-	
+
 	void Explode() JMP_THIS(0x738680);
-	
+
 	bool GotoClearSpot() JMP_THIS(0x738D30);
 	bool TryToDeploy() JMP_THIS(0x7393C0);
 	void Deploy() JMP_THIS(0x739AC0);


### PR DESCRIPTION
rename `TechnoClass::vt_entry_2CC(DWORD)` to `CanReachLocation(CoordStruct*)`

BTW Is `CanReachLocation(CoordStruct&)` identical to it?