### PR TITLE
Remove unnecessary ATL base include from Interfaces.h

### DIFF
--- a/Interfaces.h
+++ b/Interfaces.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <windows.h>
-#include <atlbase.h>
 #include <GeneralDefinitions.h>
 
 #include <comdef.h>


### PR DESCRIPTION
All interfaces we need are in the Windows SDK.